### PR TITLE
Fix homepage reference in podspec

### DIFF
--- a/OLGhostAlertView.podspec
+++ b/OLGhostAlertView.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.license  = 'Public Domain'
   s.platform = :ios
   s.summary  = 'Temporary and unobtrusive translucent alert view for iPhone and iPad.'
-  s.homepage = 'https://github.com/AFNetworking/AFNetworking'
+  s.homepage = 'https://github.com/ondalabs/OLGhostAlertView'
   s.authors  = { 'Radu Dutzan' => 'radu@ondalabs.com'}
   s.source   = { :git => 'https://github.com/ondalabs/OLGhostAlertView.git', :tag => '1.1.1' }
   s.source_files = '*.{h,m}'


### PR DESCRIPTION
The homepage specified in the podspec file was (presumably) pointing at the wrong place.  I updated it to point to this repo.
