### PR TITLE
remove unnecessary object allocation

### DIFF
--- a/OLGhostAlertView.m
+++ b/OLGhostAlertView.m
@@ -343,8 +343,8 @@
     
     _style = style;
     
-    UIColor *backgroundColor = [UIColor colorWithWhite:0 alpha:.45];
-    UIColor *textColor = [UIColor whiteColor];
+    UIColor *backgroundColor = nil;
+    UIColor *textColor = nil;
     
     if (style == OLGhostAlertViewStyleLight) {
         backgroundColor = [UIColor colorWithWhite:1 alpha:0.95];


### PR DESCRIPTION
Remove 2 unnecessary object allocations (variables are overwritten in the next if/else statement without ever being read).
