### PR TITLE
Fixed placement between the alert and the keyboard

### DIFF
--- a/OLGhostAlertView.h
+++ b/OLGhostAlertView.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSUInteger, OLGhostAlertViewStyle) {
 - (id)initWithTitle:(NSString *)title message:(NSString *)message;
 - (id)initWithTitle:(NSString *)title message:(NSString *)message timeout:(NSTimeInterval)timeout dismissible:(BOOL)dismissible;
 - (void)show;
-- (void)showInView:(UIView *)view;
+- (void)showInView:(UIView *)view  __attribute__((deprecated("Use 'show' instead.")));
 - (void)hide;
 
 @property (nonatomic) OLGhostAlertViewPosition position;

--- a/OLGhostAlertViewDemo/OLGhostAlertViewDemo/OLViewController.m
+++ b/OLGhostAlertViewDemo/OLGhostAlertViewDemo/OLViewController.m
@@ -50,7 +50,7 @@
         [demo2 show];
         
     };
-    [demo showInView:self.view];
+    [demo show];
 }
 
 - (void)didReceiveMemoryWarning


### PR DESCRIPTION
Changes made regarding an issue #3:
- added class `OLGhostAlertWindow` which is responsible for displaying
  an OLGhostAlertView above the application keyWindow. It has methods to
  show/hide alert above the application main window, which allows it to
  be independent of the system keyboard.
- removed properties in `OLGhostAlertView` that are no longer needed:
  `keyboardIsVisible`, `keyboardHeight`
- added new properties in `OLGhostAlertView`: `alertWindow`,
  `viewController`
- modified methods responsible for initialization, showing/hiding the
  alert and laying out subviews
- removed methods and notifications related to the keyboard, which are
  no longer needed: `keyboardWillShow:`, `keyboardWillHide`,
  `UIKeyboardWillShowNotification`, `UIKeyboardWillHideNotification`
- set method `showInView:` as deprecated
